### PR TITLE
fix: enable touchpad support on Acerus

### DIFF
--- a/dots/config/mango/inputs.conf
+++ b/dots/config/mango/inputs.conf
@@ -10,3 +10,14 @@ mouse_natural_scrolling=0
 accel_profile=2
 # move window by mouse
 drag_tile_to_tile=1
+
+# trackpad
+disable_trackpad=0
+tap_to_click=1
+tap_and_drag=1
+drag_lock=1
+trackpad_natural_scrolling=1
+disable_while_typing=0
+scroll_method=1
+click_method=2
+send_events_mode=0

--- a/modules/hosts/acerus.nix
+++ b/modules/hosts/acerus.nix
@@ -25,6 +25,17 @@ let
         # kernel plus the usual firmware/microcode baseline.
         boot.kernelPackages = pkgs.linuxPackages_latest;
 
+        # The internal touchpad on SFG14-73 variants is exposed as an ACPI
+        # I2C-HID device behind Intel Serial IO. Load this stack early so the
+        # touchpad is consistently present for libinput/Wayland.
+        boot.initrd.kernelModules = [
+          "intel_lpss"
+          "intel_lpss_pci"
+          "i2c_designware_pci"
+          "i2c_hid_acpi"
+          "hid_multitouch"
+        ];
+
         hardware.cpu.intel.updateMicrocode = true;
         hardware.enableRedistributableFirmware = true;
 

--- a/modules/users/seraphyne.nix
+++ b/modules/users/seraphyne.nix
@@ -51,6 +51,7 @@
       {
         users.users.${constants.user_two} = {
           extraGroups = [
+            "input"
             "uinput"
           ];
 


### PR DESCRIPTION
close NDD-55

## Summary
- Load Intel Serial IO and I2C-HID touchpad modules early for Acerus so the internal touchpad is available to libinput/Wayland
- Enable Mango trackpad options for tapping, dragging, natural scrolling, and click behavior
- Add the user to the input group for input device access

## Testing
- Not run; PR creation only